### PR TITLE
Remove error_highlight gem to fix bundler conflict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ end
 
 group :development do
   gem 'web-console'
-  gem 'error_highlight', '>= 0.4.0', platforms: [:ruby]
   gem 'bundle-audit', '~> 0.1.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,6 @@ GEM
     docile (1.4.1)
     drb (2.2.3)
     erb (5.1.3)
-    error_highlight (0.7.0)
     erubi (1.13.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
@@ -391,7 +390,6 @@ DEPENDENCIES
   capybara
   city-state
   debug
-  error_highlight (>= 0.4.0)
   factory_bot_rails (~> 6.4)
   faker (~> 3.0)
   importmap-rails


### PR DESCRIPTION
- error_highlight is a default gem in Ruby 3.3.6
- Specifying it explicitly causes version conflicts in CI
- Removing it allows bundler to use the default version
- Regenerate Gemfile.lock without error_highlight